### PR TITLE
Do not configure the repository by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,7 +112,7 @@ docker_proxy_no_proxy:
 ##########################
 # repository
 
-docker_configure_repository: yes
+docker_configure_repository: no
 
 docker_debian_repository_arch: amd64
 docker_debian_repository_key: https://download.docker.com/linux/ubuntu/gpg

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,6 +4,7 @@
 
   vars:
     docker_compose_install_from_url: yes
+    docker_configure_repository: yes
     docker_configure_storage_block_device: yes
     docker_opts:
       mtu: 0


### PR DESCRIPTION
Within OSISM we always use osism.repository for this. Therefore it is
ok to omit this by default.