### PR TITLE
Add mode parameter

### DIFF
--- a/tasks/install-docker-Debian.yml
+++ b/tasks/install-docker-Debian.yml
@@ -29,6 +29,7 @@
     state: present
     filename: docker
     update_cache: yes
+    mode: 0644
   become: true
   when: docker_configure_repository|bool
 
@@ -39,6 +40,7 @@
       Pin: version {{ docker_version }}*
       Pin-Priority: 1001
     dest: /etc/apt/preferences.d/docker
+    mode: 0644
   become: true
 
 - name: Pin cli package version
@@ -48,6 +50,7 @@
       Pin: version {{ docker_version }}*
       Pin-Priority: 1001
     dest: /etc/apt/preferences.d/docker-cli
+    mode: 0644
   become: true
 
 - name: Unlock containerd package


### PR DESCRIPTION
[WARNING]: File 'xxx' created with default '600'. The previous default
was '666'. Specify 'mode' to avoid this warning.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>