### PR TITLE
Fix AnsibleUndefinedVariable issue in daemon.json.j2 template

### DIFF
--- a/templates/daemon.json.j2
+++ b/templates/daemon.json.j2
@@ -1,4 +1,4 @@
-{{- docker_registry_mirrors.append('http://127.0.0.1:65001') if docker_dragonfly|bool -}}
+{{- docker_registry_mirrors.append('http://127.0.0.1:65001') if docker_dragonfly|bool else none -}}
 {
 {% if docker_opts|length %}
 {% for key, value in docker_opts|dictsort %}


### PR DESCRIPTION
AnsibleUndefinedVariable: the inline if-expression on line 1 evaluated
to false and no else section was defined.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>