### PR TITLE
molecule: disable kata

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,7 +12,6 @@
       - scope: global
         base: 10.20.0.0/16
         size: 24
-    docker_kata_install: yes
     docker_opts:
       mtu: 0
       selinux-enabled: false


### PR DESCRIPTION
The repository '[...]stable-1.11/xUbuntu_18.04  InRelease' is not signed."

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>